### PR TITLE
[Feature] 가게 도메인 API 구현

### DIFF
--- a/src/main/java/danji/danjiapi/domain/auth/controller/AuthController.java
+++ b/src/main/java/danji/danjiapi/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import danji.danjiapi.domain.auth.dto.response.AuthLoginResponse;
 import danji.danjiapi.domain.auth.service.AuthService;
 import danji.danjiapi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +20,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    @Operation(summary = "로그인", description = "이메일 아이디와 비밀번호로 로그인을 진행합니다. 로그인의 결과를 통해 회원의 역할을 구분합니다.")
+    @Operation(summary = "로그인", description = "이메일 아이디와 비밀번호로 로그인을 진행합니다. 로그인의 결과를 통해 회원의 역할을 구분합니다.",
+            security = @SecurityRequirement(name = ""))
     public ApiResponse<AuthLoginResponse> login(@Valid @RequestBody AuthLoginRequest request) {
         return ApiResponse.success(authService.login(request));
     }

--- a/src/main/java/danji/danjiapi/domain/market/controller/MarketController.java
+++ b/src/main/java/danji/danjiapi/domain/market/controller/MarketController.java
@@ -1,0 +1,27 @@
+package danji.danjiapi.domain.market.controller;
+
+import danji.danjiapi.domain.market.dto.request.MarketSearchCondition;
+import danji.danjiapi.domain.market.dto.response.MarketSummary;
+import danji.danjiapi.domain.market.service.MarketService;
+import danji.danjiapi.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/markets")
+@RequiredArgsConstructor
+public class MarketController {
+    private final MarketService marketService;
+
+    @GetMapping("")
+    @Operation(summary = "가게 둘러보기", description = "회원이 모든 가게들의 목록을 조회하고, 키워드로 원하는 가게를 검색합니다.")
+    public ApiResponse<List<MarketSummary>> getMarkets(@ModelAttribute MarketSearchCondition searchCondition) {
+        return ApiResponse.success(marketService.searchMarkets(searchCondition));
+    }
+
+}

--- a/src/main/java/danji/danjiapi/domain/market/dto/request/MarketSearchCondition.java
+++ b/src/main/java/danji/danjiapi/domain/market/dto/request/MarketSearchCondition.java
@@ -1,0 +1,6 @@
+package danji.danjiapi.domain.market.dto.request;
+
+public record MarketSearchCondition(
+        String keyword
+) {
+}

--- a/src/main/java/danji/danjiapi/domain/market/dto/response/MarketSummary.java
+++ b/src/main/java/danji/danjiapi/domain/market/dto/response/MarketSummary.java
@@ -1,0 +1,19 @@
+package danji.danjiapi.domain.market.dto.response;
+
+import danji.danjiapi.domain.market.entity.Market;
+
+public record MarketSummary(
+        Long id,
+        String name,
+        String address,
+        String imageUrl
+) {
+    public static MarketSummary from(Market market) {
+        return new MarketSummary(
+                market.getId(),
+                market.getName(),
+                market.getAddress(),
+                market.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/danji/danjiapi/domain/market/entity/Market.java
+++ b/src/main/java/danji/danjiapi/domain/market/entity/Market.java
@@ -1,15 +1,20 @@
 package danji.danjiapi.domain.market.entity;
 
+import danji.danjiapi.domain.product.entity.Product;
 import danji.danjiapi.domain.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +51,9 @@ public class Market {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
+    @OneToMany(mappedBy = "market", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Product> products = new ArrayList<>();
+
     public static Market create(String name, String address, String imageUrl, User user) {
         return Market.builder()
                 .name(name)
@@ -53,5 +61,10 @@ public class Market {
                 .imageUrl(imageUrl)
                 .user(user)
                 .build();
+    }
+
+    public void addProduct(Product product) {
+        products.add(product);
+        product.setMarket(this);
     }
 }

--- a/src/main/java/danji/danjiapi/domain/market/entity/Market.java
+++ b/src/main/java/danji/danjiapi/domain/market/entity/Market.java
@@ -1,0 +1,57 @@
+package danji.danjiapi.domain.market.entity;
+
+import danji.danjiapi.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "markets")
+public class Market {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 30, nullable = false)
+    private String name;
+
+    @Column(length = 30, nullable = false)
+    private String address;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    public static Market create(String name, String address, String imageUrl, User user) {
+        return Market.builder()
+                .name(name)
+                .address(address)
+                .imageUrl(imageUrl)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
+++ b/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
@@ -1,7 +1,21 @@
 package danji.danjiapi.domain.market.repository;
 
 import danji.danjiapi.domain.market.entity.Market;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MarketRepository extends JpaRepository<Market, Long> {
+
+    @Query("""
+        SELECT DISTINCT m FROM Market m
+        LEFT JOIN m.products p
+        WHERE
+            (:keyword IS NULL OR :keyword = ''
+            OR m.name LIKE %:keyword%
+            OR m.address LIKE %:keyword%
+            OR p.name LIKE %:keyword%)
+    """)
+    List<Market> findByNameOrAddressOrProductsContaining(@Param("keyword") String keyword);
 }

--- a/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
+++ b/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
@@ -12,8 +12,7 @@ public interface MarketRepository extends JpaRepository<Market, Long> {
         SELECT DISTINCT m FROM Market m
         LEFT JOIN m.products p
         WHERE
-            (:keyword IS NULL OR :keyword = ''
-            OR m.name LIKE %:keyword%
+            (m.name LIKE %:keyword%
             OR m.address LIKE %:keyword%
             OR p.name LIKE %:keyword%)
     """)

--- a/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
+++ b/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
@@ -1,0 +1,7 @@
+package danji.danjiapi.domain.market.repository;
+
+import danji.danjiapi.domain.market.entity.Market;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MarketRepository extends JpaRepository<Market, Long> {
+}

--- a/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
+++ b/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
@@ -1,0 +1,29 @@
+package danji.danjiapi.domain.market.service;
+
+import danji.danjiapi.domain.market.dto.request.MarketSearchCondition;
+import danji.danjiapi.domain.market.dto.response.MarketSummary;
+import danji.danjiapi.domain.market.entity.Market;
+import danji.danjiapi.domain.market.repository.MarketRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MarketService {
+    private final MarketRepository marketRepository;
+
+    public List<MarketSummary> searchMarkets(MarketSearchCondition searchCondition) {
+        List<Market> markets;
+
+        if (searchCondition == null) {
+            markets = marketRepository.findAll();
+        } else {
+            markets = marketRepository.findByNameOrAddressOrProductsContaining(searchCondition.keyword());
+        }
+
+        return markets.stream()
+                .map(MarketSummary::from)
+                .toList();
+    }
+}

--- a/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
+++ b/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
@@ -16,10 +16,10 @@ public class MarketService {
     public List<MarketSummary> searchMarkets(MarketSearchCondition searchCondition) {
         List<Market> markets;
 
-        if (searchCondition == null) {
+        if (searchCondition == null || searchCondition.keyword() == null || searchCondition.keyword().trim().isEmpty()) {
             markets = marketRepository.findAll();
         } else {
-            markets = marketRepository.findByNameOrAddressOrProductsContaining(searchCondition.keyword());
+            markets = marketRepository.findByNameOrAddressOrProductsContaining(searchCondition.keyword().trim());
         }
 
         return markets.stream()

--- a/src/main/java/danji/danjiapi/domain/product/entity/Product.java
+++ b/src/main/java/danji/danjiapi/domain/product/entity/Product.java
@@ -1,0 +1,56 @@
+package danji.danjiapi.domain.product.entity;
+
+import danji.danjiapi.domain.market.entity.Market;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "products")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+
+    @Column
+    private Integer minQuantity;
+
+    @Column
+    private Integer maxQuantity;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_id", nullable = false)
+    private Market market;
+
+}

--- a/src/main/java/danji/danjiapi/domain/user/controller/UserController.java
+++ b/src/main/java/danji/danjiapi/domain/user/controller/UserController.java
@@ -7,6 +7,7 @@ import danji.danjiapi.domain.user.dto.response.UserCreateCustomerResponse;
 import danji.danjiapi.domain.user.service.UserService;
 import danji.danjiapi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,13 +22,15 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup/customer")
-    @Operation(summary = "일반 회원 가입", description = "일반 회원의 회원 가입을 진행합니다.")
+    @Operation(summary = "일반 회원 가입", description = "일반 회원의 회원 가입을 진행합니다.",
+            security = @SecurityRequirement(name = ""))
     public ApiResponse<UserCreateCustomerResponse> signupCustomer(@Valid @RequestBody UserCreateCustomerRequest request) {
         return ApiResponse.success(userService.signupCustomer(request));
     }
 
     @PostMapping("/signup/merchant")
-    @Operation(summary = "사장님 회원 가입", description = "사장님의 회원 가입을 진행합니다. 회원 가입과 가게 생성이 하나의 프로세스로 진행됩니다.")
+    @Operation(summary = "사장님 회원 가입", description = "사장님의 회원 가입을 진행합니다. 회원 가입과 가게 생성이 하나의 프로세스로 진행됩니다.",
+            security = @SecurityRequirement(name = ""))
     public ApiResponse<UserCreateMerchantResponse> signupMerchant(@Valid @RequestBody UserCreateMerchantRequest request) {
         return ApiResponse.success(userService.signupMerchant(request));
     }

--- a/src/main/java/danji/danjiapi/domain/user/controller/UserController.java
+++ b/src/main/java/danji/danjiapi/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package danji.danjiapi.domain.user.controller;
 
-import danji.danjiapi.domain.user.dto.request.UserCreateRequest;
-import danji.danjiapi.domain.user.dto.response.UserCreateResponse;
+import danji.danjiapi.domain.user.dto.request.UserCreateCustomerRequest;
+import danji.danjiapi.domain.user.dto.request.UserCreateMerchantRequest;
+import danji.danjiapi.domain.user.dto.response.UserCreateMerchantResponse;
+import danji.danjiapi.domain.user.dto.response.UserCreateCustomerResponse;
 import danji.danjiapi.domain.user.service.UserService;
 import danji.danjiapi.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,9 +20,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("/signup")
-    @Operation(summary = "회원 가입", description = "이메일 아이디로 회원 가입을 진행합니다.")
-    public ApiResponse<UserCreateResponse> signup(@Valid @RequestBody UserCreateRequest request) {
-        return ApiResponse.success(userService.signup(request));
+    @PostMapping("/signup/customer")
+    @Operation(summary = "일반 회원 가입", description = "일반 회원의 회원 가입을 진행합니다.")
+    public ApiResponse<UserCreateCustomerResponse> signupCustomer(@Valid @RequestBody UserCreateCustomerRequest request) {
+        return ApiResponse.success(userService.signupCustomer(request));
+    }
+
+    @PostMapping("/signup/merchant")
+    @Operation(summary = "사장님 회원 가입", description = "사장님의 회원 가입을 진행합니다. 회원 가입과 가게 생성이 하나의 프로세스로 진행됩니다.")
+    public ApiResponse<UserCreateMerchantResponse> signupMerchant(@Valid @RequestBody UserCreateMerchantRequest request) {
+        return ApiResponse.success(userService.signupMerchant(request));
     }
 }

--- a/src/main/java/danji/danjiapi/domain/user/dto/request/UserCreateCustomerRequest.java
+++ b/src/main/java/danji/danjiapi/domain/user/dto/request/UserCreateCustomerRequest.java
@@ -1,0 +1,15 @@
+package danji.danjiapi.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserCreateCustomerRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다")
+        String password,
+        @NotBlank(message = "이름은 필수입니다")
+        String name
+) {
+}

--- a/src/main/java/danji/danjiapi/domain/user/dto/request/UserCreateMerchantRequest.java
+++ b/src/main/java/danji/danjiapi/domain/user/dto/request/UserCreateMerchantRequest.java
@@ -3,7 +3,7 @@ package danji.danjiapi.domain.user.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record UserCreateRequest(
+public record UserCreateMerchantRequest(
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
@@ -11,7 +11,12 @@ public record UserCreateRequest(
         String password,
         @NotBlank(message = "이름은 필수입니다")
         String name,
-        @NotBlank(message = "역할 정보가 누락되었습니다")
-        String role
+
+        @NotBlank(message = "상호명은 필수입니다.")
+        String marketName,
+        @NotBlank(message = "주소는 필수입니다.")
+        String marketAddress,
+        String marketImageUrl
 ) {
+
 }

--- a/src/main/java/danji/danjiapi/domain/user/dto/response/UserCreateCustomerResponse.java
+++ b/src/main/java/danji/danjiapi/domain/user/dto/response/UserCreateCustomerResponse.java
@@ -3,16 +3,14 @@ package danji.danjiapi.domain.user.dto.response;
 import lombok.Builder;
 
 @Builder
-public record UserCreateResponse(
+public record UserCreateCustomerResponse(
         Long id,
-        String email,
         String name,
         String role
 ) {
-    public static UserCreateResponse from(Long id, String email, String name, String role) {
-        return UserCreateResponse.builder()
+    public static UserCreateCustomerResponse from(Long id, String name, String role) {
+        return UserCreateCustomerResponse.builder()
                 .id(id)
-                .email(email)
                 .name(name)
                 .role(role)
                 .build();

--- a/src/main/java/danji/danjiapi/domain/user/dto/response/UserCreateMerchantResponse.java
+++ b/src/main/java/danji/danjiapi/domain/user/dto/response/UserCreateMerchantResponse.java
@@ -1,0 +1,20 @@
+package danji.danjiapi.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record UserCreateMerchantResponse(
+        Long id,
+        String name,
+        String role,
+        Long marketId
+) {
+    public static UserCreateMerchantResponse from(Long id, String name, String role, Long marketId) {
+        return UserCreateMerchantResponse.builder()
+                .id(id)
+                .name(name)
+                .role(role)
+                .marketId(marketId)
+                .build();
+    }
+}

--- a/src/main/java/danji/danjiapi/domain/user/repository/UserRepository.java
+++ b/src/main/java/danji/danjiapi/domain/user/repository/UserRepository.java
@@ -5,5 +5,6 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/danji/danjiapi/domain/user/service/UserService.java
+++ b/src/main/java/danji/danjiapi/domain/user/service/UserService.java
@@ -1,25 +1,46 @@
 package danji.danjiapi.domain.user.service;
 
-import danji.danjiapi.domain.user.dto.request.UserCreateRequest;
-import danji.danjiapi.domain.user.dto.response.UserCreateResponse;
+import danji.danjiapi.domain.market.entity.Market;
+import danji.danjiapi.domain.market.repository.MarketRepository;
+import danji.danjiapi.domain.user.dto.request.UserCreateCustomerRequest;
+import danji.danjiapi.domain.user.dto.request.UserCreateMerchantRequest;
+import danji.danjiapi.domain.user.dto.response.UserCreateMerchantResponse;
+import danji.danjiapi.domain.user.dto.response.UserCreateCustomerResponse;
 import danji.danjiapi.domain.user.entity.User;
 import danji.danjiapi.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final MarketRepository marketRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public UserCreateResponse signup(UserCreateRequest request) {
-        // TO DO: 이메일 중복 체크
+    public UserCreateCustomerResponse signupCustomer(UserCreateCustomerRequest request) {
+        // TO DO: 이메일 중복 체크 -> 두 화면 유지 시 API 따로 생성?
         String encodedPassword = passwordEncoder.encode(request.password());
 
-        User user = userRepository.save(User.create(request.email(), encodedPassword, request.name(), request.role()));
+        User user = userRepository.save(User.create(request.email(), encodedPassword, request.name(), "CUSTOMER"));
 
-        return UserCreateResponse.from(user.getId(), user.getEmail(),user.getName(), user.getRole().name());
+        return UserCreateCustomerResponse.from(user.getId(), user.getName(), user.getRole().name());
+    }
+
+
+    @Transactional
+    public UserCreateMerchantResponse signupMerchant(UserCreateMerchantRequest request) {
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        User user = userRepository.save(User.create(request.email(), encodedPassword, request.name(), "MERCHANT"));
+        Market market = marketRepository.save(Market.create(
+                request.marketName(),
+                request.marketAddress(),
+                request.marketImageUrl(),
+                user));
+
+        return UserCreateMerchantResponse.from(user.getId(), user.getName(), user.getRole().name(), market.getId());
     }
 }

--- a/src/main/java/danji/danjiapi/global/config/SecurityConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/login",
-                                "/api/users/signup",
+                                "/api/users/signup/customer",
+                                "/api/users/signup/merchant",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"

--- a/src/main/java/danji/danjiapi/global/config/SwaggerConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,13 +13,15 @@ import org.springframework.context.annotation.Configuration;
                 title = "단지 API 명세서",
                 description = "단지(단체 주문 지키미)의 비즈니스 로직에 대한 API 명세서입니다.",
                 version = "1.0"
-        )
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
 )
 @SecurityScheme(
-        name = "Authorization",
-        type = SecuritySchemeType.APIKEY,
-        in = SecuritySchemeIn.HEADER,
-        paramName = "Authorization"
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER
 )
 @Configuration
 public class SwaggerConfig {

--- a/src/main/java/danji/danjiapi/global/exception/ErrorMessage.java
+++ b/src/main/java/danji/danjiapi/global/exception/ErrorMessage.java
@@ -22,6 +22,9 @@ public enum ErrorMessage {
     CONFLICT("CONFLICT", "리소스 충돌이 발생하였습니다.", HttpStatus.CONFLICT),
     INTERNAL_ERROR("INTERNAL_ERROR", "알 수 없는 서버 내부 오류가 발생하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    //user
+    USER_DUPLICATED_EMAIL("USER_DUPLICATED_EMAIL", "이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
+
     // auth
     AUTH_INVALID("AUTH_INVALID", "잘못된 토큰입니다.", HttpStatus.BAD_REQUEST),
     AUTH_FORBIDDEN("AUTH_FORBIDDEN", "권한 정보가 없는 토큰입니다.", HttpStatus.FORBIDDEN),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 가게 목록 조회 및 키워드 검색 기능이 추가되었습니다.
  * 고객 회원가입과 사장님 회원가입이 각각 별도의 엔드포인트로 분리되었습니다.
  * 사장님 회원가입 시 가게 정보 입력 및 생성이 한 번에 처리됩니다.

* **버그 수정**
  * API 문서(Swagger)에서 JWT Bearer 인증 방식이 명확히 표시되도록 개선되었습니다.
  * 회원가입 시 이메일 중복 검증 로직이 추가되었습니다.

* **리팩터링**
  * 회원가입 요청 및 응답 DTO가 고객/판매자용으로 각각 분리 및 명확화되었습니다.

* **문서화**
  * Swagger/OpenAPI 문서에 보안 요구 사항 및 엔드포인트 설명이 추가·수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->