### PR TITLE
[Feature] 가게 목록 조회 페이지네이션

### DIFF
--- a/src/main/java/danji/danjiapi/domain/market/controller/MarketController.java
+++ b/src/main/java/danji/danjiapi/domain/market/controller/MarketController.java
@@ -36,8 +36,7 @@ public class MarketController {
             @PageableDefault(size = 10) Pageable pageable
     ) {
         log.info("GET /api/markets");
-        Slice<MarketDetail> result = marketService.searchMarkets(searchCondition, pageable);
-        return ApiResponse.success(PaginationResponse.from(result));
+        return ApiResponse.success(marketService.searchMarkets(searchCondition, pageable));
     }
 
     @GetMapping("/{marketId}/products")

--- a/src/main/java/danji/danjiapi/domain/market/controller/MarketController.java
+++ b/src/main/java/danji/danjiapi/domain/market/controller/MarketController.java
@@ -5,10 +5,14 @@ import danji.danjiapi.domain.market.dto.response.MarketDetail;
 import danji.danjiapi.domain.market.service.MarketService;
 import danji.danjiapi.domain.market.dto.response.ProductDetail;
 import danji.danjiapi.global.response.ApiResponse;
+import danji.danjiapi.global.response.PaginationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,10 +27,17 @@ public class MarketController {
     private final MarketService marketService;
 
     @GetMapping("")
-    @Operation(summary = "가게 목록 조회 및 검색", description = "고객이 모든 가게들의 목록을 조회하고, 키워드로 원하는 가게를 검색합니다.")
-    public ApiResponse<List<MarketDetail>> getMarkets(@ModelAttribute MarketSearchCondition searchCondition) {
+    @Operation(
+            summary = "가게 목록 조회 및 검색",
+            description = "고객이 모든 가게들의 목록을 페이지 단위로 조회하고, 키워드로 원하는 가게를 검색합니다."
+    )
+    public ApiResponse<PaginationResponse<MarketDetail>> getMarkets(
+            @ModelAttribute MarketSearchCondition searchCondition,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
         log.info("GET /api/markets");
-        return ApiResponse.success(marketService.searchMarkets(searchCondition));
+        Slice<MarketDetail> result = marketService.searchMarkets(searchCondition, pageable);
+        return ApiResponse.success(PaginationResponse.from(result));
     }
 
     @GetMapping("/{marketId}/products")

--- a/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
+++ b/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
@@ -4,6 +4,8 @@ import danji.danjiapi.domain.market.entity.Market;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,5 +25,5 @@ public interface MarketRepository extends JpaRepository<Market, Long> {
             OR m.address LIKE %:keyword%
             OR p.name LIKE %:keyword%)
     """)
-    List<Market> findByNameOrAddressOrProductsContaining(@Param("keyword") String keyword);
+    Slice<Market> findByNameOrAddressOrProductsContaining(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
+++ b/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
@@ -9,10 +9,13 @@ import danji.danjiapi.domain.product.entity.Product;
 import danji.danjiapi.domain.product.repository.ProductRepository;
 import danji.danjiapi.global.exception.CustomException;
 import danji.danjiapi.global.exception.ErrorMessage;
+import danji.danjiapi.global.response.PaginationResponse;
 import danji.danjiapi.global.util.resolver.CurrentUserResolver;
 import danji.danjiapi.global.util.validator.AccessValidator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,18 +25,16 @@ public class MarketService {
     private final ProductRepository productRepository;
     private final CurrentUserResolver currentUserResolver;
 
-    public List<MarketDetail> searchMarkets(MarketSearchCondition searchCondition) {
-        List<Market> markets;
+    public PaginationResponse<MarketDetail> searchMarkets(MarketSearchCondition searchCondition, Pageable pageable) {
+        Slice<Market> markets;
 
         if (searchCondition == null || searchCondition.keyword() == null || searchCondition.keyword().trim().isEmpty()) {
-            markets = marketRepository.findAll();
+            markets = marketRepository.findAll(pageable);
         } else {
-            markets = marketRepository.findByNameOrAddressOrProductsContaining(searchCondition.keyword().trim());
+            markets = marketRepository.findByNameOrAddressOrProductsContaining(searchCondition.keyword().trim(), pageable);
         }
 
-        return markets.stream()
-                .map(MarketDetail::from)
-                .toList();
+        return PaginationResponse.from(markets.map(MarketDetail::from));
     }
 
     public List<ProductDetail> getProducts(Long marketId) {

--- a/src/main/java/danji/danjiapi/global/response/PaginationResponse.java
+++ b/src/main/java/danji/danjiapi/global/response/PaginationResponse.java
@@ -1,9 +1,13 @@
 package danji.danjiapi.global.response;
 
 import java.util.List;
+import org.springframework.data.domain.Slice;
 
 public record PaginationResponse<T>(
         List<T> items,
         boolean hasNext
 ) {
+    public static <T> PaginationResponse<T> from(Slice<T> slice) {
+        return new PaginationResponse<>(slice.getContent(), slice.hasNext());
+    }
 }

--- a/src/main/java/danji/danjiapi/global/response/PaginationResponse.java
+++ b/src/main/java/danji/danjiapi/global/response/PaginationResponse.java
@@ -1,0 +1,9 @@
+package danji.danjiapi.global.response;
+
+import java.util.List;
+
+public record PaginationResponse<T>(
+        List<T> items,
+        boolean hasNext
+) {
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 가게 목록 조회 API에 페이지네이션 기능이 추가되어, 가게 정보를 10개씩 무한 스크롤 방식으로 확인할 수 있습니다.

* **문서**
  * 가게 목록 조회 API의 Swagger 설명이 페이지네이션 적용에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->