### PR TITLE
[Feature] Valkey 기반 가게 목록 조회 캐싱 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@
 <br>
 
 ### 서버 아키텍처
-![system-architecture-MVP-aws](https://github.com/user-attachments/assets/9c5d8b6c-f896-4742-a1a4-247b74ef2ba8)
+
+[//]: # (![system-architecture-MVP-aws]&#40;https://github.com/user-attachments/assets/9c5d8b6c-f896-4742-a1a4-247b74ef2ba8&#41;)
+
+![system-architecture-caching](https://github.com/user-attachments/assets/370cbfc2-ba51-4e9e-85dd-a52b05de51fa)
 
 <br>
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - .env.api
     depends_on:
       - postgres
+      - valkey
 
   chat:
     image: ${AWS_ECR}/danji-chat:latest
@@ -22,6 +23,7 @@ services:
       - .env.chat
     depends_on:
       - mongo
+      - valkey
 
   postgres:
     image: postgres:15
@@ -46,3 +48,12 @@ services:
       - ${MONGO_DATA}:/data/db
     ports:
       - "27017:27017"
+
+  valkey:
+    image: valkey/valkey:8.1.3-alpine
+    container_name: danji-valkey
+    restart: unless-stopped
+    volumes:
+      - ${VALKEY_DATA}:/data/db
+    ports:
+      - "6379:6379"

--- a/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
+++ b/src/main/java/danji/danjiapi/domain/market/repository/MarketRepository.java
@@ -26,4 +26,14 @@ public interface MarketRepository extends JpaRepository<Market, Long> {
             OR p.name LIKE %:keyword%)
     """)
     Slice<Market> findByNameOrAddressOrProductsContaining(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("""
+        SELECT DISTINCT m FROM Market m
+        LEFT JOIN m.products p
+        WHERE
+            (m.name LIKE %:keyword%
+            OR m.address LIKE %:keyword%
+            OR p.name LIKE %:keyword%)
+    """)
+    List<Market> findByNameOrAddressOrProductsContaining(@Param("keyword") String keyword);
 }

--- a/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
+++ b/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
@@ -15,6 +15,7 @@ import danji.danjiapi.global.util.validator.AccessValidator;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -22,11 +23,23 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class MarketService {
     private final MarketRepository marketRepository;
     private final ProductRepository productRepository;
     private final CurrentUserResolver currentUserResolver;
+
+    public MarketService(
+            MarketRepository marketRepository,
+            ProductRepository productRepository,
+            CurrentUserResolver currentUserResolver,
+            @Qualifier("cacheRedisTemplate") RedisTemplate<String, Object> redisTemplate
+    ) {
+        this.marketRepository = marketRepository;
+        this.productRepository = productRepository;
+        this.currentUserResolver = currentUserResolver;
+        this.redisTemplate = redisTemplate;
+    }
+
     @Qualifier("cacheRedisTemplate")
     private final RedisTemplate<String, Object> redisTemplate;
 

--- a/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
+++ b/src/main/java/danji/danjiapi/domain/market/service/MarketService.java
@@ -68,7 +68,7 @@ public class MarketService {
                 : "market:search:" + keyword;
         int start = (int) pageable.getOffset();
 
-        @SuppressWarnings("unchecked") // JSON 역직렬화를 위해 ObjectMapper에 객체 타입 정보 따로 저장하므로 unchecked warning 제거
+        @SuppressWarnings("unchecked") // 내부적으로 타입 정보 포함하는 Serializer 사용하므로 unchecked warning 제거
         List<MarketDetail> cachedMarkets = (List<MarketDetail>) redisTemplate.opsForValue().get(cacheKey);
 
         if (cachedMarkets != null) {

--- a/src/main/java/danji/danjiapi/global/config/RedisConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/RedisConfig.java
@@ -1,9 +1,5 @@
 package danji.danjiapi.global.config;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +8,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -61,13 +57,7 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.activateDefaultTyping(
-                LaissezFaireSubTypeValidator.instance,
-                DefaultTyping.NON_FINAL,
-                As.PROPERTY
-        );
-        Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        GenericJackson2JsonRedisSerializer jsonRedisSerializer = new GenericJackson2JsonRedisSerializer();
         redisTemplate.setValueSerializer(jsonRedisSerializer);
         redisTemplate.setHashValueSerializer(jsonRedisSerializer);
 

--- a/src/main/java/danji/danjiapi/global/config/RedisConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/RedisConfig.java
@@ -1,16 +1,14 @@
 package danji.danjiapi.global.config;
 
-import java.time.Duration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -22,12 +20,12 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
-//    @Bean
-//    public LettuceConnectionFactory tokenRedisConnectionFactory() {
-//        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
-//        configuration.setDatabase(0);
-//        return new LettuceConnectionFactory(configuration);
-//    }
+    @Bean
+    public LettuceConnectionFactory tokenRedisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        configuration.setDatabase(0);
+        return new LettuceConnectionFactory(configuration);
+    }
 
     @Bean
     public LettuceConnectionFactory cacheRedisConnectionFactory() {
@@ -36,30 +34,29 @@ public class RedisConfig {
         return new LettuceConnectionFactory(configuration);
     }
 
-    @Bean
-    RedisCacheManager cacheManager() {
-        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class)));
+//    @Bean
+//    @Qualifier("tokenRedisTemplate")
+//    RedisTemplate<String, Object> tokenRedisTemplate() {
+//        return redisTemplateResolver(tokenRedisConnectionFactory());
+//    }
 
-        return RedisCacheManager
-                .builder(cacheRedisConnectionFactory())
-                .cacheDefaults(cacheConfiguration)
-                .build();
+    @Bean
+    @Qualifier("cacheRedisTemplate")
+    RedisTemplate<String, Object> cacheRedisTemplate() {
+        return redisTemplateResolver(cacheRedisConnectionFactory());
     }
 
-//    @Bean
-//    RedisTemplate<String, Object> redisTemplate() {
-//        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-//        redisTemplate.setConnectionFactory(tokenRedisConnectionFactory());
-//
-//        redisTemplate.setKeySerializer(new StringRedisSerializer());
-//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-//
-//        Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
-//        redisTemplate.setValueSerializer(jsonRedisSerializer);
-//        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
-//
-//        return redisTemplate;
-//    }
+    private RedisTemplate<String, Object> redisTemplateResolver(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        redisTemplate.setValueSerializer(jsonRedisSerializer);
+        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
+
+        return redisTemplate;
+    }
 }

--- a/src/main/java/danji/danjiapi/global/config/RedisConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/RedisConfig.java
@@ -25,6 +25,7 @@ public class RedisConfig {
     private int port;
 
     @Bean
+    @Qualifier("tokenRedisConnectionFactory")
     public LettuceConnectionFactory tokenRedisConnectionFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
         configuration.setDatabase(0);
@@ -32,22 +33,25 @@ public class RedisConfig {
     }
 
     @Bean
+    @Qualifier("cacheRedisConnectionFactory")
     public LettuceConnectionFactory cacheRedisConnectionFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
         configuration.setDatabase(1);
         return new LettuceConnectionFactory(configuration);
     }
 
-//    @Bean
-//    @Qualifier("tokenRedisTemplate")
-//    RedisTemplate<String, Object> tokenRedisTemplate() {
-//        return redisTemplateResolver(tokenRedisConnectionFactory());
-//    }
+    @Bean
+    @Qualifier("tokenRedisTemplate")
+    RedisTemplate<String, Object> tokenRedisTemplate(
+            @Qualifier("tokenRedisConnectionFactory") RedisConnectionFactory redisConnectionFactory) {
+        return redisTemplateResolver(redisConnectionFactory);
+    }
 
     @Bean
     @Qualifier("cacheRedisTemplate")
-    RedisTemplate<String, Object> cacheRedisTemplate() {
-        return redisTemplateResolver(cacheRedisConnectionFactory());
+    RedisTemplate<String, Object> cacheRedisTemplate(
+            @Qualifier("cacheRedisConnectionFactory") RedisConnectionFactory redisConnectionFactory) {
+        return redisTemplateResolver(redisConnectionFactory);
     }
 
     private RedisTemplate<String, Object> redisTemplateResolver(RedisConnectionFactory connectionFactory) {

--- a/src/main/java/danji/danjiapi/global/config/RedisConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/RedisConfig.java
@@ -1,14 +1,19 @@
 package danji.danjiapi.global.config;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@Configuration
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")
@@ -17,23 +22,44 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+//    @Bean
+//    public LettuceConnectionFactory tokenRedisConnectionFactory() {
+//        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+//        configuration.setDatabase(0);
+//        return new LettuceConnectionFactory(configuration);
+//    }
+
     @Bean
-    public LettuceConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    public LettuceConnectionFactory cacheRedisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        configuration.setDatabase(1);
+        return new LettuceConnectionFactory(configuration);
     }
 
     @Bean
-    RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(connectionFactory);
+    RedisCacheManager cacheManager() {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class)));
 
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-
-        Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
-        redisTemplate.setValueSerializer(jsonRedisSerializer);
-        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
-
-        return redisTemplate;
+        return RedisCacheManager
+                .builder(cacheRedisConnectionFactory())
+                .cacheDefaults(cacheConfiguration)
+                .build();
     }
+
+//    @Bean
+//    RedisTemplate<String, Object> redisTemplate() {
+//        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+//        redisTemplate.setConnectionFactory(tokenRedisConnectionFactory());
+//
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//
+//        Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
+//        redisTemplate.setValueSerializer(jsonRedisSerializer);
+//        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
+//
+//        return redisTemplate;
+//    }
 }

--- a/src/main/java/danji/danjiapi/global/config/RedisConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package danji.danjiapi.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
+        redisTemplate.setValueSerializer(jsonRedisSerializer);
+        redisTemplate.setHashValueSerializer(jsonRedisSerializer);
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/danji/danjiapi/global/config/RedisConfig.java
+++ b/src/main/java/danji/danjiapi/global/config/RedisConfig.java
@@ -1,5 +1,9 @@
 package danji.danjiapi.global.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +57,12 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                DefaultTyping.NON_FINAL,
+                As.PROPERTY
+        );
         Jackson2JsonRedisSerializer<Object> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(Object.class);
         redisTemplate.setValueSerializer(jsonRedisSerializer);
         redisTemplate.setHashValueSerializer(jsonRedisSerializer);

--- a/src/main/java/danji/danjiapi/global/response/PaginationResponse.java
+++ b/src/main/java/danji/danjiapi/global/response/PaginationResponse.java
@@ -7,6 +7,9 @@ public record PaginationResponse<T>(
         List<T> items,
         boolean hasNext
 ) {
+    public static <T> PaginationResponse<T> from(List<T> items, boolean hasNext) {
+        return new PaginationResponse<>(items, hasNext);
+    }
     public static <T> PaginationResponse<T> from(Slice<T> slice) {
         return new PaginationResponse<>(slice.getContent(), slice.hasNext());
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,3 +6,7 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: true
+
+  data:
+    redis:
+      host: localhost

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,4 @@
+spring:
+  data:
+    redis:
+      host: valkey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      port: 6379
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Related Issues
  * #16 

## PR Description
* **새로운 기능**
  * 가게 검색 결과 API에 캐싱 기능이 추가되었습니다.
  * 캐시에는 검색 키워드별 전체 결과 리스트가 저장되며, 클라이언트 요청 시에는 애플리케이션 레벨에서 페이지네이션을 적용해 일부 데이터만 응답합니다.
  * Cache Hit의 경우, DB 조회 없이도 페이지네이션 결과를 빠르게 제공할 수 있습니다.
  * Cache Miss의 경우, DB에서 검색한 뒤 결과를 캐시에 저장하며, 검색 결과가 없을 경우 빈 리스트를 저장하여 반복적인 쿼리를 방지합니다.

* **환경 구성**
  * Redis(Valkey) 서비스가 Docker Compose에 추가되었습니다.
  * Spring Boot에서 Redis 연동을 위한 의존성과 설정이 추가되었습니다.
  * 운영 및 로컬 환경에 맞는 Redis 접속 정보가 환경별 설정 파일에 반영되었습니다.

* **문서화**
  * 시스템 아키텍처 이미지가 최신 구조로 교체되었습니다.